### PR TITLE
fix decompression

### DIFF
--- a/src/backwater_encoding_gzip.erl
+++ b/src/backwater_encoding_gzip.erl
@@ -29,13 +29,6 @@
 -export([decode/2]).
 
 %% ------------------------------------------------------------------
-%% Macro Definitions
-%% ------------------------------------------------------------------
-
-% taken from zlib.erl at Erlang/OTP source code
--define(MAX_WBITS, 15).
-
-%% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
@@ -45,22 +38,10 @@ encode(Data) ->
 
 -spec decode(iodata(), non_neg_integer()) -> {ok, binary()} | {error, term()}.
 decode(Data, MaxUncompressedSize) ->
-    Z = zlib:open(),
-    try
-        zlib:inflateInit(Z, 16 + ?MAX_WBITS),
-        zlib:setBufSize(Z, MaxUncompressedSize),
-        case zlib:inflateChunk(Z, Data) of
-            {more, _Chunk} ->
-                {error, too_big};
-            UncompressedIoData ->
-                zlib:inflateEnd(Z),
-                UncompressedData = iolist_to_binary(UncompressedIoData),
-                true = (byte_size(UncompressedData) =< MaxUncompressedSize),
-                {ok, UncompressedData}
-        end
+    try UncompressedIoData = zlib:gunzip(Data),
+	UncompressedData = iolist_to_binary(UncompressedIoData),
+	true = byte_size(UncompressedData) =< MaxUncompressedSize,
+	{ok, UncompressedData}
     catch
-        error:Reason ->
-            {error, Reason}
-    after
-        zlib:close(Z)
+      error:Reason -> {error, Reason}
     end.


### PR DESCRIPTION
For some reason decompression doesn't work in OTP 22 with error:

```
** (ErlangError) Erlang error: :data_error
    :zlib.inflate_nif(#Reference<0.953875491.103153665.170731>, 8192, 8388608, 0)
    :zlib.inflateChunk/1
```

but this solution works fine: `zlib:gunzip(Data),`